### PR TITLE
Cache pip's cache and pythons+ 2.6, 3.2, 3.3, 3.5, pypy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,17 @@
 sudo: false
 language: python
 python:
+  - "2.6"
   - "2.7"
+  - "3.3"
   - "3.4"
+  - "pypy"
+cache:
+  directories:
+    - $HOME/.pip-cache/
 install:
-  - "pip install -e .[test]"
+  - "pip install -U pip --cache-dir $HOME/.pip-cache"
+  - "pip install -e .[test] --cache-dir $HOME/.pip-cache"
 script: 
   - py.test --cov mapbox --cov-report term-missing
 after_success:

--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,11 @@ with open('mapbox/__init__.py') as f:
 
 setup(name='mapbox',
       version=version,
-      description=u"A Python client for Mapbox services",
+      description="A Python client for Mapbox services",
       long_description=long_description,
       classifiers=[],
       keywords='',
-      author=u"Sean Gillies",
+      author="Sean Gillies",
       author_email='sean@mapbox.com',
       url='https://github.com/mapbox/mapbox-sdk-py',
       license='MIT',


### PR DESCRIPTION
Python 2.5 is too old to be concerned about. Pythons 3.0 and 3.1 aren't to be used. Python 3.2 is missing unicode literals but we can support it with care. Python 3.5 isn't released yet and is unstable with respect to pytest.