### PR TITLE
Geocoder place types

### DIFF
--- a/mapbox/__init__.py
+++ b/mapbox/__init__.py
@@ -9,11 +9,18 @@ from uritemplate import URITemplate
 __version__ = "0.1.0"
 
 
+class InvalidPlaceTypeError(KeyError):
+    pass
+
+
 class Service:
     """Base service class"""
 
     def get_session(self, token=None, env=None):
-        access_token = token or (env or os.environ).get('MapboxAccessToken')
+        access_token = (
+            token or
+            (env or os.environ).get('MapboxAccessToken') or
+            (env or os.environ).get('MAPBOX_ACCESS_TOKEN'))
         session = requests.Session()
         session.params.update(access_token=access_token)
         return session
@@ -27,18 +34,42 @@ class Geocoder(Service):
         self.baseuri = 'https://api.mapbox.com/v4/geocode'
         self.session = self.get_session(access_token)
 
-    def forward(self, address, params=None):
+    def _validate_place_types(self, place_types):
+        """Validate place types and return a mapping for use in requests"""
+        for pt in place_types:
+            if pt not in self.place_types:
+                raise InvalidPlaceTypeError(pt)
+        return {'types': ",".join(place_types)}
+
+    def forward(self, address, place_types=None):
         """A forward geocoding request
 
-        See: https://www.mapbox.com/developers/api/geocoding/#forward"""
+        See: https://www.mapbox.com/developers/api/geocoding/#forward."""
         uri = URITemplate('%s/{dataset}/{query}.json' % self.baseuri).expand(
             dataset=self.name, query=address)
+        params = {}
+        if place_types:
+            params.update(self._validate_place_types(place_types))
         return self.session.get(uri, params=params)
 
-    def reverse(self, lon, lat, params=None):
+    def reverse(self, lon, lat, place_types=None):
         """A reverse geocoding request
 
-        See: https://www.mapbox.com/developers/api/geocoding/#reverse"""
+        See: https://www.mapbox.com/developers/api/geocoding/#reverse."""
         uri = URITemplate(self.baseuri + '/{dataset}/{lon},{lat}.json').expand(
             dataset=self.name, lon=str(lon), lat=str(lat))
+        params = {}
+        if place_types:
+            params.update(self._validate_place_types(place_types))
         return self.session.get(uri, params=params)
+
+    @property
+    def place_types(self):
+        """A mapping of place type names to descriptions"""
+        return {
+            'address': "A street address with house number. Examples: 1600 Pennsylvania Ave NW, 1051 Market St, Oberbaumstrasse 7.",
+            'country': "Sovereign states and other political entities. Examples: United States, France, China, Russia.",
+            'place': "City, town, village or other municipality relevant to a country's address or postal system. Examples: Cleveland, Saratoga Springs, Berlin, Paris.",
+            'poi': "Places of interest including commercial venues, major landmarks, parks, and other features. Examples: Yosemite National Park, Lake Superior.",
+            'postcode': "Postal code, varies by a country's postal system. Examples: 20009, CR0 3RL.",
+            'region': "First order administrative divisions within a country, usually provinces or states. Examples: California, Ontario, Essonne."}

--- a/mapbox/__init__.py
+++ b/mapbox/__init__.py
@@ -34,14 +34,14 @@ class Geocoder(Service):
         self.baseuri = 'https://api.mapbox.com/v4/geocode'
         self.session = self.get_session(access_token)
 
-    def _validate_place_types(self, place_types):
+    def _validate_place_types(self, types):
         """Validate place types and return a mapping for use in requests"""
-        for pt in place_types:
+        for pt in types:
             if pt not in self.place_types:
                 raise InvalidPlaceTypeError(pt)
-        return {'types': ",".join(place_types)}
+        return {'types': ",".join(types)}
 
-    def forward(self, address, place_types=None, lng=None, lat=None):
+    def forward(self, address, types=None, lng=None, lat=None):
         """A forward geocoding request
 
         Results may be constrained to those in a sequence of place_types or
@@ -51,21 +51,21 @@ class Geocoder(Service):
         uri = URITemplate('%s/{dataset}/{query}.json' % self.baseuri).expand(
             dataset=self.name, query=address)
         params = {}
-        if place_types:
-            params.update(self._validate_place_types(place_types))
+        if types:
+            params.update(self._validate_place_types(types))
         if lng is not None and lat is not None:
             params.update(proximity='{0},{1}'.format(lng, lat))
         return self.session.get(uri, params=params)
 
-    def reverse(self, lon, lat, place_types=None):
+    def reverse(self, lon, lat, types=None):
         """A reverse geocoding request
 
         See: https://www.mapbox.com/developers/api/geocoding/#reverse."""
         uri = URITemplate(self.baseuri + '/{dataset}/{lon},{lat}.json').expand(
             dataset=self.name, lon=str(lon), lat=str(lat))
         params = {}
-        if place_types:
-            params.update(self._validate_place_types(place_types))
+        if types:
+            params.update(self._validate_place_types(types))
         return self.session.get(uri, params=params)
 
     @property

--- a/mapbox/__init__.py
+++ b/mapbox/__init__.py
@@ -41,8 +41,11 @@ class Geocoder(Service):
                 raise InvalidPlaceTypeError(pt)
         return {'types': ",".join(place_types)}
 
-    def forward(self, address, place_types=None):
+    def forward(self, address, place_types=None, lng=None, lat=None):
         """A forward geocoding request
+
+        Results may be constrained to those in a sequence of place_types or
+        biased toward a given longitude and latitude.
 
         See: https://www.mapbox.com/developers/api/geocoding/#forward."""
         uri = URITemplate('%s/{dataset}/{query}.json' % self.baseuri).expand(
@@ -50,6 +53,8 @@ class Geocoder(Service):
         params = {}
         if place_types:
             params.update(self._validate_place_types(place_types))
+        if lng is not None and lat is not None:
+            params.update(proximity='{0},{1}'.format(lng, lat))
         return self.session.get(uri, params=params)
 
     def reverse(self, lon, lat, place_types=None):

--- a/mapbox/scripts/cli.py
+++ b/mapbox/scripts/cli.py
@@ -35,10 +35,11 @@ def main_group(ctx, verbose, quiet, access_token):
 
       $ mbx --access-token MY_TOKEN ...
 
-    or as an environment variable.
+    or as an environment variable named MAPBOX_ACCESS_TOKEN or 
+    MapboxAccessToken.
 
     \b
-      $ export MapboxAccessToken=MY_TOKEN
+      $ export MAPBOX_ACCESS_TOKEN=MY_TOKEN
       $ mbx ...
 
     """

--- a/mapbox/scripts/geocoder.py
+++ b/mapbox/scripts/geocoder.py
@@ -89,7 +89,7 @@ def geocode(ctx, query, include_headers, forward, lat, lng, place_type, output):
     if forward:
         for q in iter_query(query):
             resp = geocoder.forward(
-                q, place_types=place_type, lat=lat, lng=lng)
+                q, types=place_type, lat=lat, lng=lng)
             if include_headers:
                 echo_headers(resp.headers, file=stdout)
             if resp.status_code == 200:
@@ -98,7 +98,7 @@ def geocode(ctx, query, include_headers, forward, lat, lng, place_type, output):
                 raise MapboxCLIException(resp.text.strip())
     else:
         for coords in map(coords_from_query, iter_query(query)):
-            resp = geocoder.reverse(*coords, place_types=place_type)
+            resp = geocoder.reverse(*coords, types=place_type)
             if include_headers:
                 echo_headers(resp.headers, file=stdout)
             if resp.status_code == 200:

--- a/tests/test_geocoder.py
+++ b/tests/test_geocoder.py
@@ -1,5 +1,6 @@
 import json
 import responses
+
 import mapbox
 
 
@@ -19,6 +20,14 @@ def test_service_session_env():
 def test_service_session_os_environ(monkeypatch):
     """Get a session using os.environ's token"""
     monkeypatch.setenv('MapboxAccessToken', 'pk.test_os_environ')
+    session = mapbox.Service().get_session()
+    assert session.params.get('access_token') == 'pk.test_os_environ'
+    monkeypatch.undo()
+
+
+def test_service_session_os_environ_caps(monkeypatch):
+    """Get a session using os.environ's token"""
+    monkeypatch.setenv('MAPBOX_ACCESS_TOKEN', 'pk.test_os_environ')
     session = mapbox.Service().get_session()
     assert session.params.get('access_token') == 'pk.test_os_environ'
     monkeypatch.undo()
@@ -67,5 +76,69 @@ def test_geocoder_reverse():
         content_type='application/json')
 
     response = mapbox.Geocoder(access_token='pk.test').reverse(*[str(x) for x in coords])
+    assert response.status_code == 200
+    assert response.json()['query'] == coords
+
+
+def test_geocoder_place_types():
+    """Place types are enumerated"""
+    assert sorted(mapbox.Geocoder().place_types.items()) == [
+        ('address', "A street address with house number. Examples: 1600 Pennsylvania Ave NW, 1051 Market St, Oberbaumstrasse 7."),
+        ('country', "Sovereign states and other political entities. Examples: United States, France, China, Russia."),
+        ('place', "City, town, village or other municipality relevant to a country's address or postal system. Examples: Cleveland, Saratoga Springs, Berlin, Paris."),
+        ('poi', "Places of interest including commercial venues, major landmarks, parks, and other features. Examples: Yosemite National Park, Lake Superior."),
+        ('postcode', "Postal code, varies by a country's postal system. Examples: 20009, CR0 3RL."),
+        ('region', "First order administrative divisions within a country, usually provinces or states. Examples: California, Ontario, Essonne.")]
+
+
+def test_validate_place_types_err():
+    try:
+        mapbox.Geocoder()._validate_place_types(('address', 'bogus'))
+    except mapbox.InvalidPlaceTypeError as err:
+        assert str(err) == "'bogus'"
+
+
+def test_validate_place_types():
+    assert mapbox.Geocoder()._validate_place_types(
+        ('address', 'poi')) == {'types': 'address,poi'}
+
+
+@responses.activate
+def test_geocoder_forward_types():
+    """Type filtering of forward geocoding works"""
+
+    responses.add(
+        responses.GET,
+        'https://api.mapbox.com/v4/geocode/mapbox.places/1600%20pennsylvania%20ave%20nw.json?types=address,country,place,poi,postcode,region&access_token=pk.test',
+        match_querystring=True,
+        body='{"query": ["1600", "pennsylvania", "ave", "nw"]}', status=200,
+        content_type='application/json')
+
+    response = mapbox.Geocoder(
+        access_token='pk.test').forward(
+            '1600 pennsylvania ave nw',
+            place_types=('address', 'country', 'place', 'poi', 'postcode', 'region'))
+    assert response.status_code == 200
+    assert response.json()['query'] == ["1600", "pennsylvania", "ave", "nw"]
+
+
+@responses.activate
+def test_geocoder_reverse_types():
+    """Type filtering of reverse geocoding works"""
+
+    coords = [-77.4371, 37.5227]
+
+    responses.add(
+        responses.GET,
+        'https://api.mapbox.com/v4/geocode/mapbox.places/%s.json?types=address,country,place,poi,postcode,region&access_token=pk.test' % ','.join([str(x) for x in coords]),
+        match_querystring=True,
+        body='{"query": %s}' % json.dumps(coords),
+        status=200,
+        content_type='application/json')
+
+    response = mapbox.Geocoder(
+        access_token='pk.test').reverse(
+            *[str(x) for x in coords],
+            place_types=('address', 'country', 'place', 'poi', 'postcode', 'region'))
     assert response.status_code == 200
     assert response.json()['query'] == coords

--- a/tests/test_geocoder.py
+++ b/tests/test_geocoder.py
@@ -117,7 +117,7 @@ def test_geocoder_forward_types():
     response = mapbox.Geocoder(
         access_token='pk.test').forward(
             '1600 pennsylvania ave nw',
-            place_types=('address', 'country', 'place', 'poi', 'postcode', 'region'))
+            types=('address', 'country', 'place', 'poi', 'postcode', 'region'))
     assert response.status_code == 200
     assert response.json()['query'] == ["1600", "pennsylvania", "ave", "nw"]
 
@@ -139,7 +139,7 @@ def test_geocoder_reverse_types():
     response = mapbox.Geocoder(
         access_token='pk.test').reverse(
             *[str(x) for x in coords],
-            place_types=('address', 'country', 'place', 'poi', 'postcode', 'region'))
+            types=('address', 'country', 'place', 'poi', 'postcode', 'region'))
     assert response.status_code == 200
     assert response.json()['query'] == coords
 

--- a/tests/test_geocoder.py
+++ b/tests/test_geocoder.py
@@ -142,3 +142,21 @@ def test_geocoder_reverse_types():
             place_types=('address', 'country', 'place', 'poi', 'postcode', 'region'))
     assert response.status_code == 200
     assert response.json()['query'] == coords
+
+
+@responses.activate
+def test_geocoder_forward_proximity():
+    """Proximity parameter works"""
+
+    responses.add(
+        responses.GET,
+        'https://api.mapbox.com/v4/geocode/mapbox.places/1600%20pennsylvania%20ave%20nw.json?proximity=0,0&access_token=pk.test',
+        match_querystring=True,
+        body='{"query": ["1600", "pennsylvania", "ave", "nw"]}', status=200,
+        content_type='application/json')
+
+    response = mapbox.Geocoder(
+        access_token='pk.test').forward(
+            '1600 pennsylvania ave nw', lng=0, lat=0)
+    assert response.status_code == 200
+    assert response.json()['query'] == ["1600", "pennsylvania", "ave", "nw"]


### PR DESCRIPTION
Add place type filtering and proximity biasing.

In the API, these are new keyword arguments to the `forward()` and `reverse()` methods. To side step coordinate order confusion, I've made `lng` and `lat` separate keywords. They can be given in either order.

Are results returned sorted by proximity to the given lng, lat? That would be a useful fact to convey to users.

Closes #11
Closes #12