### PR TITLE
Geometry encoding

### DIFF
--- a/mapbox/encoding.py
+++ b/mapbox/encoding.py
@@ -19,13 +19,7 @@ def read_points(features):
     """
     for feature in features:
 
-        if feature['type'] == 'Feature':
-            # A GeoJSON-like mapping
-            geom = feature['geometry']
-            for pt in _geom_points(geom):
-                yield pt
-
-        elif hasattr(feature, '__geo_interface__'):
+        if hasattr(feature, '__geo_interface__'):
             # An object implementing the geo_interface
             try:
                 # Could be a Feature...
@@ -36,6 +30,12 @@ def read_points(features):
                 # ... or a geometry directly
                 for pt in _geom_points(feature.__geo_interface__):
                     yield pt
+
+        elif feature['type'] == 'Feature':
+            # A GeoJSON-like mapping
+            geom = feature['geometry']
+            for pt in _geom_points(geom):
+                yield pt
 
         else:
             raise ValueError("Unknown object: Not a GeoJSON feature or "

--- a/mapbox/encoding.py
+++ b/mapbox/encoding.py
@@ -1,0 +1,64 @@
+
+def _geom_points(geom):
+    """GeoJSON geometry to a sequence of point tuples
+    """
+    if geom['type'] == 'Point':
+        yield tuple(geom['coordinates'])
+    elif geom['type'] in ('MultiPoint', 'LineString'):
+        for position in geom['coordinates']:
+            yield tuple(position)
+    else:
+        raise ValueError(
+            "Unsupported geometry type:{0}".format(geom['type']))
+
+
+def read_points(features):
+    """ Iterable of features to a sequence of point tuples
+    Where "features" can be either GeoJSON mappings
+    or objects implementing the geo_interface
+    """
+    for feature in features:
+
+        if feature['type'] == 'Feature':
+            # A GeoJSON-like mapping
+            geom = feature['geometry']
+            for pt in _geom_points(geom):
+                yield pt
+
+        elif hasattr(feature, '__geo_interface__'):
+            # An object implementing the geo_interface
+            try:
+                # Could be a Feature...
+                geom = feature.__geo_interface__['geometry']
+                for pt in _geom_points(geom):
+                    yield pt
+            except KeyError:
+                # ... or a geometry directly
+                for pt in _geom_points(feature.__geo_interface__):
+                    yield pt
+
+        else:
+            raise ValueError("Unknown object: Not a GeoJSON feature or "
+                             "an object with __geo_interface__:\n{0}".format(feature))
+
+
+def encode_waypoints(features, min_limit=None, max_limit=None, precision=6):
+    """Given an iterable of features
+    return a string encoded in waypoint-style used by certain mapbox APIs
+    ("lon,lat" pairs separated by ";")
+    """
+    coords = ['{lon:.{p}f},{lat:.{p}f}'.format(lon=lon, lat=lat, p=precision)
+              for lon, lat in read_points(features)]
+
+    if min_limit is not None and len(coords) < min_limit:
+        raise ValueError("Not enough features to encode waypoints, "
+                         "need at least {0}".format(min_limit))
+    if max_limit is not None and len(coords) > max_limit:
+        raise ValueError("Too many features to encode waypoints, "
+                         "need at most {0}".format(max_limit))
+
+    return ';'.join(coords)
+
+
+# TODO
+# def encode_polyline(features, zoom_level=18):

--- a/mapbox/encoding.py
+++ b/mapbox/encoding.py
@@ -1,3 +1,5 @@
+from polyline.codec import PolylineCodec
+
 
 def _geom_points(geom):
     """GeoJSON geometry to a sequence of point tuples
@@ -31,7 +33,7 @@ def read_points(features):
                 for pt in _geom_points(feature.__geo_interface__):
                     yield pt
 
-        elif feature['type'] == 'Feature':
+        elif 'type' in feature and feature['type'] == 'Feature':
             # A GeoJSON-like mapping
             geom = feature['geometry']
             for pt in _geom_points(geom):
@@ -60,5 +62,7 @@ def encode_waypoints(features, min_limit=None, max_limit=None, precision=6):
     return ';'.join(coords)
 
 
-# TODO
-# def encode_polyline(features, zoom_level=18):
+def encode_polyline(features, zoom_level=18):
+    points = list(read_points(features))
+    codec = PolylineCodec()
+    return codec.encode(points)

--- a/mapbox/encoding.py
+++ b/mapbox/encoding.py
@@ -1,4 +1,5 @@
 from polyline.codec import PolylineCodec
+import json
 
 
 def _geom_points(geom):
@@ -63,6 +64,19 @@ def encode_waypoints(features, min_limit=None, max_limit=None, precision=6):
 
 
 def encode_polyline(features, zoom_level=18):
+    """Encode and iterable of features as a polyline
+    """
     points = list(read_points(features))
     codec = PolylineCodec()
     return codec.encode(points)
+
+
+def encode_coordinates_json(features):
+    """Given an iterable of features
+    return a JSON string to be used as the request body for the distance API:
+    a JSON object, with a key coordinates,
+    which has an array of [ Longitude, Latitidue ] pairs
+    """
+    coords = {
+        'coordinates': list(read_points(features))}
+    return json.dumps(coords)

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,13 @@ setup(name='mapbox',
       include_package_data=True,
       zip_safe=False,
       install_requires=[
-          'click', 'click-plugins', 'cligj', 'requests', 'uritemplate.py', 'boto3'
+          'click',
+          'click-plugins',
+          'cligj',
+          'requests',
+          'uritemplate.py',
+          'boto3',
+          'polyline'
       ],
       extras_require={
           'test': ['coveralls', 'pytest', 'pytest-cov', 'responses'],

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -1,6 +1,10 @@
 import pytest
 import copy
-from mapbox.encoding import read_points, encode_waypoints, encode_polyline
+import json
+from mapbox.encoding import (read_points,
+                             encode_waypoints,
+                             encode_polyline,
+                             encode_coordinates_json)
 
 
 gj_point_features = [{
@@ -113,3 +117,14 @@ def test_encode_polyline():
     assert expected == encode_polyline(gj_point_features)
     assert expected == encode_polyline(gj_multipoint_features)
     assert expected == encode_polyline(gj_line_features)
+
+
+def test_encode_coordinates_json():
+    expected = {
+        'coordinates': [
+            [-87.33787536621092, 36.539156961321574],
+            [-88.2476806640625, 36.92217534275667]]}
+
+    assert expected == json.loads(encode_coordinates_json(gj_point_features))
+    assert expected == json.loads(encode_coordinates_json(gj_multipoint_features))
+    assert expected == json.loads(encode_coordinates_json(gj_line_features))

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -1,0 +1,86 @@
+import pytest
+from mapbox.encoding import read_points, encode_waypoints
+
+
+gj_point_features = [{
+    "type": "Feature",
+    "properties": {},
+    "geometry": {
+        "type": "Point",
+        "coordinates": [
+            -87.33787536621092,
+            36.539156961321574]}}, {
+    "type": "Feature",
+    "properties": {},
+    "geometry": {
+        "type": "Point",
+        "coordinates": [
+            -88.2476806640625,
+            36.92217534275667]}}]
+
+
+gj_multipoint_features = [{
+    "type": "Feature",
+    "properties": {},
+    "geometry": {
+        "type": "MultiPoint",
+        "coordinates": [
+            [-87.33787536621092,
+             36.539156961321574],
+            [-88.2476806640625,
+             36.92217534275667]]}}]
+
+
+gj_line_features = [{
+    "type": "Feature",
+    "properties": {},
+    "geometry": {
+        "type": "LineString",
+        "coordinates": [
+            [-87.33787536621092,
+             36.539156961321574],
+            [-88.2476806640625,
+             36.92217534275667]]}}]
+
+
+def test_read_geojson_features():
+    expected = [(-87.33787536621092, 36.539156961321574),
+                (-88.2476806640625, 36.92217534275667)]
+
+    assert expected == list(read_points(gj_point_features))
+    assert expected == list(read_points(gj_multipoint_features))
+    assert expected == list(read_points(gj_line_features))
+
+
+def test_encode_waypoints():
+    expected = "-87.337875,36.539157;-88.247681,36.922175"
+
+    assert expected == encode_waypoints(gj_point_features)
+    assert expected == encode_waypoints(gj_multipoint_features)
+    assert expected == encode_waypoints(gj_line_features)
+
+
+def test_encode_limits():
+    expected = "-87.337875,36.539157;-88.247681,36.922175"
+    assert expected == encode_waypoints(gj_point_features)
+    with pytest.raises(ValueError) as exc:
+        encode_waypoints(gj_point_features, min_limit=3)
+    assert 'at least' in str(exc.value)
+
+    with pytest.raises(ValueError) as exc:
+        encode_waypoints(gj_point_features, max_limit=1)
+    assert 'at most' in str(exc.value)
+
+
+# TODO
+# def test_unsupported_geometry():
+
+# TODO
+# def test_unknown_object():
+
+# TODO
+# def test_encode_polyline():
+#     expected = "vdatOwp_~EhupD{xiA"
+#     assert expected == encode_polyline(gj_point_features)
+#     assert expected == encode_polyline(gj_multipoint_features)
+#     assert expected == encode_polyline(gj_line_features)

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -43,6 +43,13 @@ gj_line_features = [{
              36.92217534275667]]}}]
 
 
+class GeoThing(object):
+    __geo_interface__ = None
+
+    def __init__(self, thing):
+        self.__geo_interface__ = thing
+
+
 def test_read_geojson_features():
     expected = [(-87.33787536621092, 36.539156961321574),
                 (-88.2476806640625, 36.92217534275667)]
@@ -71,6 +78,18 @@ def test_encode_limits():
         encode_waypoints(gj_point_features, max_limit=1)
     assert 'at most' in str(exc.value)
 
+
+def test_geo_interface():
+    expected = [(-87.33787536621092, 36.539156961321574),
+                (-88.2476806640625, 36.92217534275667)]
+
+    features = [GeoThing(gj_point_features[0]),
+                GeoThing(gj_point_features[1])]
+    assert expected == list(read_points(features))
+
+    geoms = [GeoThing(gj_point_features[0]['geometry']),
+             GeoThing(gj_point_features[1]['geometry'])]
+    assert expected == list(read_points(geoms))
 
 # TODO
 # def test_unsupported_geometry():


### PR DESCRIPTION
Resolves #32 - see comments there for initial discussion. The main advantage to this approach is that all API wrappers which require geometries as input can accept common python vector data structures. 

This PR adds an `encoding` module providing a few useful functions, mainly `encode_waypoints` and `encode_polyline` which take iterables of feature-like objects and return data fit for posting to mapbox APIs.

There is a dependency on [polyline](https://github.com/bmcustodio-archive/polyline) which is a nice Python2/3 port of [mapbox/polyline](https://github.com/mapbox/polyline). The other option (gpolyencode) is not Python 3 compatible and doesn't give results consistent with mapbox/polyline (see [gist](https://gist.github.com/perrygeo/3684ca73e534601db0e7))