### PR TITLE
get username from session token

### DIFF
--- a/mapbox/services/base.py
+++ b/mapbox/services/base.py
@@ -1,6 +1,8 @@
 """Base Service class"""
 
 import os
+import base64
+import json
 
 import requests
 
@@ -26,6 +28,20 @@ class Service:
     def product_token(self):
         """A product token for use in User-Agent headers."""
         return 'mapbox-sdk-py/{0}'.format(__version__)
+
+    @property
+    def username(self):
+        """Get username from access token
+        Token contains base64 encoded json object with username"""
+        token = self.session.params['access_token']
+        if not token:
+            raise ValueError("session does not have a valid access_token param")
+        data = token.split('.')[1]
+        data = data.replace('-', '+').replace('_', '/')
+        try:
+            return json.loads(base64.b64decode(data).decode('utf-8'))['u']
+        except (ValueError, KeyError):
+            raise ValueError("access_token does not contain username")
 
     def handle_http_error(self, response, custom_messages=None,
                           raise_for_status=False):

--- a/mapbox/services/uploads.py
+++ b/mapbox/services/uploads.py
@@ -11,7 +11,7 @@ class Uploader(Service):
 
         from mapbox import Uploader
 
-        u = Uploader('username')
+        u = Uploader()
         url = u.stage('test.tif')
         job = u.create(url, 'test1').json()
 
@@ -24,8 +24,7 @@ class Uploader(Service):
         assert job not in u.list().json()
     """
 
-    def __init__(self, username, access_token=None):
-        self.username = username
+    def __init__(self, access_token=None):
         self.baseuri = 'https://api.mapbox.com/uploads/v1'
         self.session = self.get_session(access_token)
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -76,7 +76,7 @@ def test_username(monkeypatch):
     assert service.username == 'testuser'
 
 def test_username_failures(monkeypatch):
-    # If your superclass doesn't create a session
+    # If your child class doesn't create a session
     service = mapbox.Service()
     with pytest.raises(AttributeError) as exc:
         service.username


### PR DESCRIPTION
* Adds a `username` property to the base service - decoded from the session's access token
* Modifies `Uploader` class to not require the username arg
* Modify upload tests to use a "real" token

fixes #81 

@sgillies one small question - the username property requires the existence of a `session` property and it's up the child class to create it. I'm pretty sure every service class will end up creating a session for itself but if not, accessing username will raise a ValueError. Is that OK?

Also, should we be testing for non-ascii usernames?