### PR TITLE
accept file objects instead of paths

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+0.6.0 (TBD)
+------------------
+- The Upload API methods `upload` and `stage` take an open file object
+  instead of a file path. Client code will need to be updated.
+
 0.5.0 (2015-12-08)
 ------------------
 - We've vendorized the `polyline` module to work around its out of date `six`

--- a/docs/uploads.md
+++ b/docs/uploads.md
@@ -40,7 +40,8 @@ In the example below, we use a string defined in a test fixture.
 >>> if upload_resp.status_code == 409:
 ...     for i in range(5):
 ...         sleep(5)
-...         upload_resp = service.upload('tests/twopoints.geojson', mapid)
+...         with open('tests/twopoints.geojson', 'r') as src:
+...             upload_resp = service.upload(src, mapid)
 ...         if upload_resp.status_code != 409:
 ...             break
 

--- a/docs/uploads.md
+++ b/docs/uploads.md
@@ -35,7 +35,8 @@ In the example below, we use a string defined in a test fixture.
 >>> from time import sleep
 >>> from random import randint
 >>> mapid = getfixture('uploads_dest_id') # 'uploads-test'
->>> upload_resp = service.upload('tests/twopoints.geojson', mapid)
+>>> with open('tests/twopoints.geojson', 'r') as src:
+...     upload_resp = service.upload(src, mapid)
 >>> if upload_resp.status_code == 409:
 ...     for i in range(5):
 ...         sleep(5)

--- a/mapbox/errors.py
+++ b/mapbox/errors.py
@@ -39,5 +39,5 @@ class InvalidParameterError(ValidationError):
     pass
 
 
-class FileIOError(ValidationError):
+class InvalidFileError(ValidationError):
     pass

--- a/mapbox/services/uploads.py
+++ b/mapbox/services/uploads.py
@@ -3,6 +3,7 @@ from boto3.session import Session as boto3_session
 from uritemplate import URITemplate
 
 from .base import Service
+from mapbox.errors import InvalidFileError
 
 
 class Uploader(Service):
@@ -47,6 +48,11 @@ class Uploader(Service):
         If creds are not provided, temporary credientials will be generated
         Returns the URL to the staged resource.
         """
+        if not hasattr(fileobj, 'read'):
+            raise InvalidFileError(
+                "Object `{0}` has no .read method, "
+                "a file-like object is required".format(fileobj))
+
         if not creds:
             res = self._get_credentials()
             creds = res.json()

--- a/mapbox/services/uploads.py
+++ b/mapbox/services/uploads.py
@@ -1,11 +1,8 @@
 # mapbox
-import os
-
 from boto3.session import Session as boto3_session
 from uritemplate import URITemplate
 
 from .base import Service
-from mapbox import errors
 
 
 class Uploader(Service):
@@ -16,7 +13,7 @@ class Uploader(Service):
         from mapbox import Uploader
 
         u = Uploader()
-        url = u.stage('test.tif')
+        url = u.stage(open('test.tif'))
         job = u.create(url, 'test1').json()
 
         assert job in u.list().json()
@@ -45,7 +42,7 @@ class Uploader(Service):
                 404: "Token does not have upload scope"})
         return resp
 
-    def stage(self, filepath, creds=None):
+    def stage(self, fileobj, creds=None):
         """Stages the user's file on S3
         If creds are not provided, temporary credientials will be generated
         Returns the URL to the staged resource.
@@ -61,11 +58,7 @@ class Uploader(Service):
             region_name="us-east-1")
 
         s3 = session.resource('s3')
-        if not os.path.exists(filepath):
-            raise errors.FileIOError(
-                "{0} does not exist".format(filepath))
-        with open(filepath, 'rb') as data:
-            res = s3.Object(creds['bucket'], creds['key']).put(Body=data)
+        res = s3.Object(creds['bucket'], creds['key']).put(Body=fileobj)
 
         return creds['url']
 
@@ -144,10 +137,10 @@ class Uploader(Service):
         self.handle_http_error(resp)
         return resp
 
-    def upload(self, filepath, tileset, name=None):
-        """High level function to upload a local file to mapbox tileset
+    def upload(self, fileobj, tileset, name=None):
+        """High level function to upload a file object to mapbox tileset
         Effectively replicates the upload functionality using the HTML form
         Returns a response object where the json() is a dict with upload metadata
         """
-        url = self.stage(filepath)
+        url = self.stage(fileobj)
         return self.create(url, tileset, name=name)


### PR DESCRIPTION
This is a breaking change to the API (affects both `.upload` and `.stage` methods of the service)

Working but needs
* [x] doctest changes
* [x] test with other file handlers like StringIO
* [x] changelog
* [x] apply to CLI and kick the tires a bit

