### PR TITLE
add datasets disclaimer, remove doc link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,11 +15,6 @@ The Mapbox Python SDK is a low-level client API, not a Resource API such as the 
 Services
 ========
 
-- **Datasets** `examples <./docs/datasets.md#datasets>`__, `website <https://www.mapbox.com/developers/api/datasets/>`__
-
-  - Manage editable collections of GeoJSON features
-  - Persistent storage for custom geographic data
-
 - **Directions** `examples <./docs/directions.md#directions>`__, `website <https://www.mapbox.com/developers/api/directions/>`__
 
   - Profiles for driving, walking, and cycling
@@ -52,6 +47,12 @@ Services
 - **Uploads** `examples <./docs/uploads.md#uploads>`__, `website <https://www.mapbox.com/developers/api/uploads/>`__
 
   - Upload data to be processed and hosted by Mapbox.
+
+- **Datasets** `examples <./docs/datasets.md#datasets>`__
+
+  - Manage editable collections of GeoJSON features
+  - Persistent storage for custom geographic data
+  - **Note: The Mapbox Datasets API is in private beta. Currently, all end user requests to this API from outside of Mapbox will 404.**
 
 Other services coming soon.
 


### PR DESCRIPTION
We get about one support request per week from a user using our Python or JS SDKs asking why they're getting 404s from the datasets API. It's because that API isn't open to anyone outside Mapbox. This PR changes the README:

- Moves Datasets API to bottom of the list
- Removes link to documentation (not currently visible on API docs page)
- Adds a note that says these requests will 404

cc @sgillies @perrygeo 