### PR TITLE
Turn off doctests for PRs from forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
   - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install ordereddict; fi
 script:
   - py.test --cov mapbox --cov-report term-missing tests/*.py
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then py.test --doctest-glob='*.md' docs/*.md; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 && ! -z "$MAPBOX_ACCESS_TOKEN" ]]; then py.test --doctest-glob='*.md' docs/*.md; fi
 after_success:
   - coveralls
 deploy:


### PR DESCRIPTION
As discovered in #107 

> Encrypted environment variables are not available to pull requests from forks due to the security risk of exposing such information to unknown code.

So doctests fail for contributions from forked repos since they require the encrypted mapbox access token.

This PR turns off the doctests when the access token environment variable is not set. This means we need to run the doctests locally as part of the review process. Not ideal but better than getting failing builds from otherwise excellent community contributions.