### PR TITLE
geocode with unicode

### DIFF
--- a/mapbox/services/geocoding.py
+++ b/mapbox/services/geocoding.py
@@ -48,7 +48,7 @@ class Geocoder(Service):
 
         See: https://www.mapbox.com/developers/api/geocoding/#forward."""
         uri = URITemplate('%s/{dataset}/{query}.json' % self.baseuri).expand(
-            dataset=self.name, query=address)
+            dataset=self.name, query=address.encode('utf-8'))
         params = {}
         if country:
             params.update(self._validate_country_codes(country))

--- a/tests/test_geocoder.py
+++ b/tests/test_geocoder.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 import json
 import re
 import responses
@@ -234,3 +236,27 @@ def test_geocoder_reverse_rounding():
     assert match is not None
     for coord in re.split(r'(%2C|,)', match.group(1)):
         assert _check_coordinate_precision(coord, 5)
+
+
+@responses.activate
+def test_geocoder_unicode():
+    """Forward geocoding works with non-ascii inputs
+    Specifically, the URITemplate needs to utf-8 encode all inputs
+    """
+
+    responses.add(
+        responses.GET,
+        'https://api.mapbox.com/geocoding/v5/mapbox.places/Florian%C3%B3polis%2C%20Brazil.json?access_token=pk.test',
+        match_querystring=True,
+        body='{}', status=200,
+        content_type='application/json')
+
+    query = "Florianópolis, Brazil"
+    try:
+        query = query.decode('utf-8')  # Python 2
+    except:
+        pass  # Python 3 
+    assert type(query) in (str, unicode)  # py3, py2
+
+    response = mapbox.Geocoder(access_token='pk.test').forward(query)
+    assert response.status_code == 200

--- a/tests/test_geocoder.py
+++ b/tests/test_geocoder.py
@@ -255,8 +255,7 @@ def test_geocoder_unicode():
     try:
         query = query.decode('utf-8')  # Python 2
     except:
-        pass  # Python 3 
-    assert type(query) in (str, unicode)  # py3, py2
+        pass  # Python 3
 
     response = mapbox.Geocoder(access_token='pk.test').forward(query)
     assert response.status_code == 200


### PR DESCRIPTION
Explicitly encode queries as utf-8

Fixes #110 

TODO
* [x] are there other CLI input arguments that need similar treatment? 

@sgillies we should do a bugfix release soon once ^ has been answered and addressed.