### PR TITLE
[TEST] fix doctests, camel and upper token envs

### DIFF
--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -25,7 +25,7 @@ generally take dataset id and feature id arguments and return an instance of
 
 ## Usage
 
-Create a new dataset using the `Dataset` class, giving it a name and 
+Create a new dataset using the `Dataset` class, giving it a name and
 description. The `id` of the created dataset is in JSON data of the response.
 
 ```python
@@ -67,10 +67,10 @@ True
 If you want to change a dataset's name or description, you can.
 
 ```python
->>> _ = datasets.update_dataset(
+>>> attrs = datasets.update_dataset(
 ...     new_id, name='updated example', description='An updated example dataset'
 ...     ).json()
->>> attrs = datasets.read_dataset(new_id).json()
+>>> # attrs = datasets.read_dataset(new_id).json()
 >>> attrs['id'] == new_id
 True
 >>> attrs['name']

--- a/docs/directions.md
+++ b/docs/directions.md
@@ -75,7 +75,7 @@ route(s) as a GeoJSON-like FeatureCollection dictionary.
 >>> driving_routes['features'][0]['geometry']['type']
 'LineString'
 >>> driving_routes['features'][0]['properties']['summary']
-'Mount Hood Highway (US 26) - Warm Springs Highway (US 26)'
+'Mount Hood Highway (US 26), Warm Springs Highway (US 26)'
 
 ```
 

--- a/docs/uploads.md
+++ b/docs/uploads.md
@@ -79,7 +79,14 @@ Finally you can delete the upload. Note that this does *not* delete the tileset 
 To delete the tileset itself, got to Mapbox Studio and delete it from the Data page.
 
 ```
->>> service.delete(upload_id)
+>>> response = service.delete(upload_id)
+>>> for i in range(5):
+...     if response.status_code == 204:
+...         break
+...     else:
+...         sleep(5)
+...         response = service.delete(upload_id)
+>>> response
 <Response [204]>
 
 ```

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -33,9 +33,19 @@ def test_service_session_os_environ(monkeypatch):
 
 def test_service_session_os_environ_caps(monkeypatch):
     """Get a session using os.environ's token"""
+    monkeypatch.delenv('MapboxAccessToken', raising=False)
     monkeypatch.setenv('MAPBOX_ACCESS_TOKEN', 'pk.test_os_environ')
     session = base.Session()
     assert session.params.get('access_token') == 'pk.test_os_environ'
+    monkeypatch.undo()
+
+
+def test_service_session_os_environ_precedence(monkeypatch):
+    """Get a session using os.environ's token"""
+    monkeypatch.setenv('MapboxAccessToken', 'pk.test_os_environ_camel')
+    monkeypatch.setenv('MAPBOX_ACCESS_TOKEN', 'pk.test_os_environ_upper')
+    session = base.Session()
+    assert session.params.get('access_token') == 'pk.test_os_environ_camel'
     monkeypatch.undo()
 
 
@@ -76,8 +86,8 @@ def test_username(monkeypatch):
 
 
 def test_username_failures(monkeypatch):
-    if 'MAPBOX_ACCESS_TOKEN' in os.environ:
-        monkeypatch.delenv('MAPBOX_ACCESS_TOKEN')
+    monkeypatch.delenv('MAPBOX_ACCESS_TOKEN', raising=False)
+    monkeypatch.delenv('MapboxAccessToken', raising=False)
     service = MockService()
     with pytest.raises(ValueError) as exc:
         service.username


### PR DESCRIPTION
Previously, having `MapboxAccessToken` set would cause some tests to fail. This gaurds against that, unsetting where necessary, and explicitly tests for precedence.

Also fixes a handful of doctest failures due to either data response changes or eventual consistency.