### PR TITLE
Fix Issue #130

### DIFF
--- a/mapbox/services/static.py
+++ b/mapbox/services/static.py
@@ -39,7 +39,7 @@ class Static(Service):
     def image(self, mapid, lon=None, lat=None, z=None, features=None,
               width=600, height=600, image_format='png256', sort_keys=False):
 
-        if lon and lat and z:
+        if lon is not None and lat is not None and z is not None:
             auto = False
             lat = self._validate_lat(lat)
             lon = self._validate_lon(lon)


### PR DESCRIPTION
Because of the way the previous version was checking for
values, a request for 0.0,0.0 at 0 zoom level would fail
as python marks 0 as falsey, as well as None (which is not intended,
only None should trigger the auto flag to be set).

Change the condition so that it only sets the auto flag when all
three are not None

Signed-off-by: Rohan Mathur <rohan@rmathur.com>