### PR TITLE
Drop the dataset batch endpoint

### DIFF
--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -104,7 +104,7 @@ create a new dataset and then add a GeoJSON feature to it.
 >>> feature = {
 ...     'type': 'Feature', 'id': '1', 'properties': {'name': 'Insula Nulla'},
 ...     'geometry': {'type': 'Point', 'coordinates': [0, 0]}}
->>> resp = datasets.batch_update_features(new_id, put=[feature])
+>>> resp = datasets.update_feature(new_id, '1', feature)
 >>> resp.status_code
 200
 
@@ -124,23 +124,6 @@ In the feature collection of the dataset you will see this feature.
 
 ```
 
-Using the same `batch_update_features()` method, you can modify or delete
-up to 100 features.
-
-```python
->>> feature2 = {
-...     'type': 'Feature', 'id': '2', 'properties': {'name': 'Insula Nulla B'},
-...     'geometry': {'type': 'Point', 'coordinates': [0, 0]}}
->>> resp = datasets.batch_update_features(new_id, put=[feature2], delete=['1'])
->>> resp.status_code
-200
-
-```
-
-Replication of the updates across data centers takes a small but finite amount
-of time. Your next call to `datasets.list_features()` may not reflect the most
-recent updates.
-
 ## Individual feature access
 
 You can also read, update, and delete features individually.
@@ -150,14 +133,14 @@ You can also read, update, and delete features individually.
 The `read_feature()` method has the semantics of HTTP GET.
 
 ```python
->>> resp = datasets.read_feature(new_id, '2')
+>>> resp = datasets.read_feature(new_id, '1')
 >>> resp.status_code
 200
 >>> feature = resp.json()
 >>> feature['id']
-'2'
+'1'
 >>> feature['properties']['name']
-'Insula Nulla B'
+'Insula Nulla'
 
 ```
 
@@ -168,11 +151,11 @@ feature in the dataset with the given id, a new feature will be created.
 
 ```python
 >>> update = {
-...     'type': 'Feature', 'id': '2', 'properties': {'name': 'Insula Nulla C'},
+...     'type': 'Feature', 'id': '1', 'properties': {'name': 'Insula Nulla C'},
 ...     'geometry': {'type': 'Point', 'coordinates': [0, 0]}}
->>> update = datasets.update_feature(new_id, '2', update).json()
+>>> update = datasets.update_feature(new_id, '1', update).json()
 >>> update['id']
-'2'
+'1'
 >>> update['properties']['name']
 'Insula Nulla C'
 
@@ -183,7 +166,7 @@ feature in the dataset with the given id, a new feature will be created.
 The `delete_feature()` method has the semantics of HTTP DELETE.
 
 ```python
->>> resp = datasets.delete_feature(new_id, '2')
+>>> resp = datasets.delete_feature(new_id, '1')
 >>> resp.status_code
 204
 

--- a/mapbox/services/datasets.py
+++ b/mapbox/services/datasets.py
@@ -104,26 +104,6 @@ class Datasets(Service):
             params['limit'] = int(limit)
         return self.session.get(uri, params=params)
 
-    def batch_update_features(self, dataset, put=None, delete=None):
-        """Update features of a dataset.
-
-        Up to 100 features may be deleted or modified in one request.
-
-        :param dataset: the dataset identifier string.
-        :param put: an array of GeoJSON features to be created or
-            modified with the semantics of HTTP PUT.
-        :param delete: an array of feature ids to be deleted with
-            the semantics of HTTP DELETE.
-        """
-        uri = URITemplate(self.baseuri + '/{owner}/{id}/features').expand(
-            owner=self.username, id=dataset)
-        updates = {}
-        if put:
-            updates['put'] = put
-        if delete:
-            updates['delete'] = delete
-        return self.session.post(uri, json=updates)
-
     def read_feature(self, dataset, fid):
         """Read a dataset feature.
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -202,28 +202,6 @@ def test_dataset_list_features_pagination():
     assert response.json()['type'] == 'FeatureCollection'
 
 
-@responses.activate
-def test_batch_update_features():
-    """Features update works"""
-
-    def request_callback(request):
-        payload = json.loads(request.body.decode())
-        assert payload['put'] == [{'type': 'Feature'}]
-        assert payload['delete'] == ['1']
-        return (200, {}, "")
-
-    responses.add_callback(
-        responses.POST,
-        'https://api.mapbox.com/datasets/v1/{0}/{1}/features?access_token={2}'.format(
-            username, 'test', access_token),
-        match_querystring=True,
-        callback=request_callback)
-
-    response = Datasets(access_token=access_token).batch_update_features(
-            'test', put=[{'type': 'Feature'}], delete=['1'])
-    assert response.status_code == 200
-
-
 # Tests of feature-scoped methods.
 
 @responses.activate


### PR DESCRIPTION
As we look to move the dataset api past beta we have decided that that batch api is not something we plan to support for the long term.

This PR drops support of it fully rather than converting the batch functionality to use the single feature `put` and `delete` endpoints.

@sgillies for the review