### PR TITLE
add district, locality to allowed place_types

### DIFF
--- a/mapbox/services/geocoding.py
+++ b/mapbox/services/geocoding.py
@@ -119,7 +119,7 @@ class Geocoder(Service):
             'address': "A street address with house number. Examples: 1600 Pennsylvania Ave NW, 1051 Market St, Oberbaumstrasse 7.",
             'country': "Sovereign states and other political entities. Examples: United States, France, China, Russia.",
             'place': "City, town, village or other municipality relevant to a country's address or postal system. Examples: Cleveland, Saratoga Springs, Berlin, Paris.",
-            'locality': "A smaller area within a place that possesses official status and boundaries. Examples: 千代田区; Oakleigh, Melbourne", 
+            'locality': "A smaller area within a place that possesses official status and boundaries. Examples: Oakleigh (Melbourne)", 
             'neighborhood': "A smaller area within a place, often without formal boundaries. Examples: Montparnasse, Downtown, Haight-Ashbury.",
             'poi': "Places of interest including commercial venues, major landmarks, parks, and other features. Examples: Subway Restaurant, Yosemite National Park, Statue of Liberty.",
             'poi.landmark': "Places of interest that are particularly notable or long-lived like parks, places of worship and museums. A strict subset of the poi place type. Examples: Yosemite National Park, Statue of Liberty.",

--- a/mapbox/services/geocoding.py
+++ b/mapbox/services/geocoding.py
@@ -119,6 +119,7 @@ class Geocoder(Service):
             'address': "A street address with house number. Examples: 1600 Pennsylvania Ave NW, 1051 Market St, Oberbaumstrasse 7.",
             'country': "Sovereign states and other political entities. Examples: United States, France, China, Russia.",
             'place': "City, town, village or other municipality relevant to a country's address or postal system. Examples: Cleveland, Saratoga Springs, Berlin, Paris.",
+            'locality': "A smaller area within a place that possesses official status and boundaries. Examples: 千代田区; Oakleigh, Melbourne", 
             'neighborhood': "A smaller area within a place, often without formal boundaries. Examples: Montparnasse, Downtown, Haight-Ashbury.",
             'poi': "Places of interest including commercial venues, major landmarks, parks, and other features. Examples: Subway Restaurant, Yosemite National Park, Statue of Liberty.",
             'poi.landmark': "Places of interest that are particularly notable or long-lived like parks, places of worship and museums. A strict subset of the poi place type. Examples: Yosemite National Park, Statue of Liberty.",

--- a/mapbox/services/geocoding.py
+++ b/mapbox/services/geocoding.py
@@ -123,4 +123,5 @@ class Geocoder(Service):
             'poi': "Places of interest including commercial venues, major landmarks, parks, and other features. Examples: Subway Restaurant, Yosemite National Park, Statue of Liberty.",
             'poi.landmark': "Places of interest that are particularly notable or long-lived like parks, places of worship and museums. A strict subset of the poi place type. Examples: Yosemite National Park, Statue of Liberty.",
             'postcode': "Postal code, varies by a country's postal system. Examples: 20009, CR0 3RL.",
+            'district': "Second order administrative division. Only used when necessary. Examples: Tianjin, Beijing",
             'region': "First order administrative divisions within a country, usually provinces or states. Examples: California, Ontario, Essonne."}

--- a/tests/test_geocoder.py
+++ b/tests/test_geocoder.py
@@ -102,6 +102,8 @@ def test_geocoder_place_types():
     assert sorted(mapbox.Geocoder().place_types.items()) == [
         ('address', "A street address with house number. Examples: 1600 Pennsylvania Ave NW, 1051 Market St, Oberbaumstrasse 7."),
         ('country', "Sovereign states and other political entities. Examples: United States, France, China, Russia."),
+        ('district', "Second order administrative division. Only used when necessary. Examples: Tianjin, Beijing"),
+        ('locality', "A smaller area within a place that possesses official status and boundaries. Examples: Oakleigh (Melbourne)"),
         ('neighborhood', 'A smaller area within a place, often without formal boundaries. Examples: Montparnasse, Downtown, Haight-Ashbury.'),
         ('place', "City, town, village or other municipality relevant to a country's address or postal system. Examples: Cleveland, Saratoga Springs, Berlin, Paris."),
         ('poi', "Places of interest including commercial venues, major landmarks, parks, and other features. Examples: Subway Restaurant, Yosemite National Park, Statue of Liberty."),


### PR DESCRIPTION
We don't use `district` very much and will probably move away from it longer-term, but we do have some live features right now and should allow it.