### PR TITLE
Lazy import of urllib3 (+requests, boto and friends, CacheControl)

### DIFF
--- a/mapbox/services/base.py
+++ b/mapbox/services/base.py
@@ -4,9 +4,6 @@ import base64
 import json
 import os
 
-from cachecontrol import CacheControl
-import requests
-
 from .. import __version__
 from mapbox import errors
 
@@ -21,6 +18,7 @@ def Session(access_token=None, env=os.environ):
         access_token or
         env.get('MapboxAccessToken') or
         env.get('MAPBOX_ACCESS_TOKEN'))
+    import requests
     session = requests.Session()
     session.params.update(access_token=access_token)
     session.headers.update({
@@ -44,6 +42,7 @@ class Service(object):
         self.session = Session(access_token)
         self.host = host or os.environ.get('MAPBOX_HOST', self.default_host)
         if cache:
+            from cachecontrol import CacheControl
             self.session = CacheControl(self.session, cache=cache)
 
     @property

--- a/mapbox/services/base.py
+++ b/mapbox/services/base.py
@@ -7,6 +7,9 @@ import os
 from .. import __version__
 from mapbox import errors
 
+# cachecontrol is imported lazily below.
+# requests is imported lazily below.
+
 
 def Session(access_token=None, env=os.environ):
     """Returns an HTTP session.

--- a/mapbox/services/datasets.py
+++ b/mapbox/services/datasets.py
@@ -1,7 +1,6 @@
 # mapbox.datasets
 import json
 
-import requests
 from uritemplate import URITemplate
 
 from mapbox.services.base import Service

--- a/mapbox/services/uploads.py
+++ b/mapbox/services/uploads.py
@@ -1,10 +1,17 @@
 import os.path
 
-from boto3.session import Session as boto3_session
+# from boto3.session import Session as boto3_session
 from uritemplate import URITemplate
 
 from mapbox.errors import InvalidFileError
 from mapbox.services.base import Service
+
+
+boto3_session = None
+
+
+def _import_boto3_session():
+    from boto3.session import Session as boto3_session
 
 
 class Uploader(Service):
@@ -59,6 +66,7 @@ class Uploader(Service):
             res = self._get_credentials()
             creds = res.json()
 
+        _import_boto3_session()
         session = boto3_session(
             aws_access_key_id=creds['accessKeyId'],
             aws_secret_access_key=creds['secretAccessKey'],

--- a/mapbox/services/uploads.py
+++ b/mapbox/services/uploads.py
@@ -1,12 +1,12 @@
 import os.path
 
-# from boto3.session import Session as boto3_session
 from uritemplate import URITemplate
 
 from mapbox.errors import InvalidFileError
 from mapbox.services.base import Service
 
 
+# A placeholder for boto3.session.Session, which we load lazily.
 boto3_session = None
 
 

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -198,7 +198,10 @@ class MockSession(object):
 
 @responses.activate
 def test_stage(monkeypatch):
-
+    # Cause `from boto3.session import Session as boto3_session` in
+    # mapbox.services.uploads.
+    mapbox.services.uploads._import_boto3_session()
+    # After, monkey patch it.
     monkeypatch.setattr(mapbox.services.uploads, 'boto3_session', MockSession)
 
     # Credentials
@@ -224,7 +227,7 @@ def test_stage(monkeypatch):
 @responses.activate
 def test_big_stage(tmpdir, monkeypatch):
     """Files larger than 1M are multipart uploaded."""
-
+    mapbox.services.uploads._import_boto3_session()
     monkeypatch.setattr(mapbox.services.uploads, 'boto3_session', MockSession)
 
     # Credentials
@@ -255,7 +258,7 @@ def test_big_stage(tmpdir, monkeypatch):
 @responses.activate
 def test_upload(monkeypatch):
     """Upload a file and create a tileset"""
-
+    mapbox.services.uploads._import_boto3_session()
     monkeypatch.setattr(mapbox.services.uploads, 'boto3_session', MockSession)
 
     # Credentials
@@ -295,7 +298,7 @@ def test_upload(monkeypatch):
 @responses.activate
 def test_upload_error(monkeypatch):
     """Upload a file and create a tileset, fails with 409"""
-
+    mapbox.services.uploads._import_boto3_session()
     monkeypatch.setattr(mapbox.services.uploads, 'boto3_session', MockSession)
 
     # Credentials
@@ -337,7 +340,7 @@ def test_invalid_fileobj():
 @responses.activate
 def test_upload_patch(monkeypatch):
     """Upload a file and create a tileset in patch mode"""
-
+    mapbox.services.uploads._import_boto3_session()
     monkeypatch.setattr(mapbox.services.uploads, 'boto3_session', MockSession)
 
     def ensure_patch(request):


### PR DESCRIPTION
Import of urllib3 can be slow due to a package scan (see https://github.com/kennethreitz/requests/issues/3213 for details). If we lazily import CacheControl (rarely needed), boto3 (only needed for uploads), and requests (only needed right before API requests), we can cut `time python -c "import mapbox"` from 0.20s to 0.08s (on my macbook).