### PR TITLE
tileset logic and account names for upload

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
-0.12.0 (soon)
+0.12.0 (2017-04-27)
 -------------
+- Fix tileset logic and allow account names for Upload endpoints.
 - Initial support for Analytics API (Premium and Enterprise accounts only).
 - Addition of Python 3.6 to the testing matrix and removal of Python 2.6,
   which is no longer supported.

--- a/mapbox/__init__.py
+++ b/mapbox/__init__.py
@@ -1,5 +1,5 @@
 # mapbox
-__version__ = "0.12"
+__version__ = "0.12.0"
 
 from .services.datasets import Datasets
 from .services.directions import Directions

--- a/mapbox/services/uploads.py
+++ b/mapbox/services/uploads.py
@@ -88,8 +88,10 @@ class Uploader(Service):
         Returns a response object where the json() contents are
         an upload dict
         """
-        if not tileset.startswith(self.username + "."):
+        if '.' not in tileset:
             tileset = "{0}.{1}".format(self.username, tileset)
+
+        account, _name = tileset.split(".")
 
         msg = {'tileset': tileset,
                'url': stage_url}
@@ -97,55 +99,64 @@ class Uploader(Service):
         if patch:
             msg['patch'] = patch
 
-        if name is not None:
-            msg['name'] = name
+        msg['name'] = name if name else _name
 
-        uri = URITemplate(self.baseuri + '/{username}').expand(
-            username=self.username)
+        uri = URITemplate(self.baseuri + '/{account}').expand(
+            account=account)
 
         resp = self.session.post(uri, json=msg)
         self.handle_http_error(resp)
         return resp
 
-    def list(self):
+    def list(self, account=None):
         """List of all uploads
 
         Returns a response object where the json() contents are
         a list of uploads
+
+        Account defaults to username
         """
-        uri = URITemplate(self.baseuri + '/{username}').expand(
-            username=self.username)
+        if account is None:
+            account = self.username
+        uri = URITemplate(self.baseuri + '/{account}').expand(
+            account=account)
         resp = self.session.get(uri)
         self.handle_http_error(resp)
         return resp
 
-    def delete(self, upload):
+    def delete(self, upload, account=None):
         """Delete the specified upload
         """
+        if account is None:
+            account = self.username
+
         if isinstance(upload, dict):
             upload_id = upload['id']
         else:
             upload_id = upload
 
-        uri = URITemplate(self.baseuri + '/{username}/{upload_id}').expand(
-            username=self.username, upload_id=upload_id)
+        uri = URITemplate(self.baseuri + '/{account}/{upload_id}').expand(
+            account=account, upload_id=upload_id)
         resp = self.session.delete(uri)
         self.handle_http_error(resp)
         return resp
 
-    def status(self, upload):
+    def status(self, upload, account=None):
         """Check status of upload
 
         Returns a response object where the json() contents are
         another (updated) upload dict
         """
+        if account is None:
+            account = self.username
+
         if isinstance(upload, dict):
             upload_id = upload['id']
         else:
             upload_id = upload
 
-        uri = URITemplate(self.baseuri + '/{username}/{upload_id}').expand(
-            username=self.username, upload_id=upload_id)
+        uri = URITemplate(self.baseuri + '/{account}/{upload_id}').expand(
+            account=account, upload_id=upload_id)
         resp = self.session.get(uri)
         self.handle_http_error(resp)
         return resp


### PR DESCRIPTION
Allows the `Uploader` service to point to different accounts.

cc @sgillies 