### PR TITLE
Branch coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
   - pip install flake8  # 127 == GitHub editor width
   - flake8 . --count --max-line-length=127 --statistics --exit-zero
 script:
-  - py.test --cov mapbox --cov-report term-missing tests/*.py
+  - py.test --cov mapbox --cov-report term-missing --cov-branch tests/*.py
   - if [[ $TRAVIS_PYTHON_VERSION == 2.7 && ! -z "$MAPBOX_ACCESS_TOKEN" ]]; then py.test --doctest-glob='*.md' docs/*.md; fi
 after_success:
   - coveralls


### PR DESCRIPTION
`coverage` allows us to see if our tests [cover all possible code paths](https://coverage.readthedocs.io/en/coverage-4.4.1/branch.html). Since this SDK has a lot of conditional logic for constructing URLs, we should assess these as part of our test coverage.

Turning on the `pytest --cov-branch` flag, looks like we're still pretty good here with only 8 conditional statements uncovered.

![image](https://user-images.githubusercontent.com/1151287/27644481-eaedf2c8-5be0-11e7-98e9-54c28042052a.png)

Using the `--cov-report html` flag, the HTML interface gives some helpful hints

![image](https://user-images.githubusercontent.com/1151287/27644828-c1e515a4-5be1-11e7-967e-bdfd6acae715.png)

Question:
Should we address these gaps in this PR or hit them up later?

cc @pratikyadav