### PR TITLE
Validate image with size 1 and 1280

### DIFF
--- a/mapbox/services/static.py
+++ b/mapbox/services/static.py
@@ -27,7 +27,7 @@ class Static(Service):
         return val
 
     def _validate_image_size(self, val):
-        if not (1 < val < 1280):
+        if not (1 <= val <= 1280):
             raise errors.ImageSizeError(
                 "Image height and width must be between 1 and 1280")
         return val


### PR DESCRIPTION
Currently, images with size `1` or `1280` give an error `Invalid value` whereas they are not invalid. Fixes mapbox/mapbox-cli-py#107