### PR TITLE
copy os.environ in Session

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,10 @@
-Next
-----
-- Permit images of size 1 and 1280 (#179).
+0.14.0 (2017-07-10)
+-------------------
+- Permit images of size 1 and 1280 (#196)
+- Retina output for static map services (#191)
+- Add languages option to forward geocoder (#192)
+- Validate tileset name length (#193)
+- Copy env when Session is called.
 
 0.13.0 (2017-05-16)
 -------------------

--- a/mapbox/services/base.py
+++ b/mapbox/services/base.py
@@ -11,12 +11,21 @@ from .. import __version__
 from mapbox import errors
 
 
-def Session(access_token=None, env=os.environ):
-    """Returns an HTTP session.
+def Session(access_token=None, env=None):
+    """Create an HTTP session.
 
-    :param access_token: Mapbox access token string (optional).
-    :param env: a dict.
+    Parameters
+    ----------
+    access_token: string
+        Mapbox access token string (optional).
+    env: dict or None
+
+    Returns
+    -------
+    requests.Session
     """
+    if env is None:
+        env = os.environ.copy()
     access_token = (
         access_token or
         env.get('MapboxAccessToken') or


### PR DESCRIPTION
Copy the environment to prevent mutating `env` from affecting the runtime environment.

Also, fills out the CHANGES for `0.14` and adds numpy-style docstring.
