### PR TITLE
fix tileset name validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - '3.4'
   - '3.5'
   - '3.6'
-  - pypy-5.3.1
+  - pypy
 cache:
   directories:
     - $HOME/.pip-cache/

--- a/docs/geocoding.md
+++ b/docs/geocoding.md
@@ -117,9 +117,9 @@ Place results may be biased toward a given longitude and latitude.
 200
 >>> first = response.geojson()['features'][0]
 >>> first['place_name']
-'200 Queen St, Saint John, New Brunswick E2L 2X1, Canada'
->>> first['geometry']['coordinates']
-[-66.050985, 45.270093]
+'200 Queen St...'
+>>> [int(coord) for coord in first['geometry']['coordinates']]
+[-66, 45]
 
 ```
 
@@ -136,8 +136,8 @@ Place results may be limited to those falling within a given bounding box.
 >>> first = response.geojson()['features'][0]
 >>> first['place_name']
 'Washington, Virginia, United States'
->>> first['geometry']['coordinates']
-[-78.1594, 38.7135]
+>>> [round(coord, 2) for coord in first['geometry']['coordinates']]
+[-78.16, 38.71]
 
 ```
 ## Forward geocoding with limited results

--- a/mapbox/services/uploads.py
+++ b/mapbox/services/uploads.py
@@ -1,6 +1,7 @@
 """
 Mapbox Uploads API
 """
+import re
 
 from boto3.session import Session as boto3_session
 from uritemplate import URITemplate
@@ -54,8 +55,12 @@ class Uploader(Service):
         """
         if '.' not in tileset:
             tileset = "{0}.{1}".format(self.username, tileset)
-        if len(tileset) > 64:
-            raise ValidationError('tileset including username must be < 64 char')
+
+        pattern = '^[a-z0-9-_]{1,32}\.[a-z0-9-_]{1,32}$'
+        if not re.match(pattern, tileset, flags=re.IGNORECASE):
+            raise ValidationError(
+                f'tileset {tileset} is invalid, must match r"{pattern}"')
+
         return tileset
 
     def stage(self, fileobj, creds=None, callback=None):

--- a/mapbox/services/uploads.py
+++ b/mapbox/services/uploads.py
@@ -59,7 +59,8 @@ class Uploader(Service):
         pattern = '^[a-z0-9-_]{1,32}\.[a-z0-9-_]{1,32}$'
         if not re.match(pattern, tileset, flags=re.IGNORECASE):
             raise ValidationError(
-                f'tileset {tileset} is invalid, must match r"{pattern}"')
+                'tileset {0} is invalid, must match r"{1}"'.format(
+                    tileset, pattern))
 
         return tileset
 

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -416,7 +416,7 @@ def test_upload_patch(monkeypatch):
 
     with open('tests/moors.json', 'rb') as src:
         res = mapbox.Uploader(access_token=access_token).upload(
-            src, 'testuser.test1', name='test1', patch=True)
+            src, 'testuser.Test1', name='test1', patch=True)
 
     assert res.status_code == 201
     job = res.json()
@@ -426,8 +426,17 @@ def test_upload_patch(monkeypatch):
 def test_upload_tileset_validation():
     with pytest.raises(mapbox.errors.ValidationError):
         with open('tests/moors.json', 'rb') as src:
+            # limited to 32 chars, try 40
             mapbox.Uploader(access_token=access_token).upload(
-                src, 'a' * 65, name='test1', patch=True)
+                src, 'username.' + 'aA' * 20, name='test1')
+
+
+def test_upload_tileset_validation_specialchar():
+    with pytest.raises(mapbox.errors.ValidationError):
+        with open('tests/moors.json', 'rb') as src:
+            # limited to a-z0-9-_ chars
+            mapbox.Uploader(access_token=access_token).upload(
+                src, 'username.&#!', name='test1')
 
 
 def test_upload_tileset_validation_username():


### PR DESCRIPTION
The recent upload [api-documentation](https://www.mapbox.com/api-documentation/#create-an-upload) contains some additional rules for tileset names:

* tileset name (not including the `username.` prefix) is limited to 32 chars
* no special characters, `a-Z 0-9 -_` only

Resolves #204 

The uuid suggestion in the doc/uploads.md is consistent with the validation rules, no need to change it.