### PR TITLE
open example test.tif in binary mode

### DIFF
--- a/mapbox/services/uploads.py
+++ b/mapbox/services/uploads.py
@@ -19,7 +19,7 @@ class Uploader(Service):
         from mapbox import Uploader
 
         u = Uploader()
-        url = u.stage(open('test.tif'))
+        url = u.stage(open('test.tif', 'rb'))
         job = u.create(url, 'test1').json()
 
         assert job in u.list().json()


### PR DESCRIPTION
As instructed in the [uploads.md](https://github.com/mapbox/mapbox-sdk-py/blob/master/docs/uploads.md#usage)