### PR TITLE
Clearer directions example

### DIFF
--- a/docs/directions.md
+++ b/docs/directions.md
@@ -31,7 +31,7 @@ route up to 25 points.  Each of your input waypoints will be visited in order
 and should be represented by a GeoJSON point feature.
 
 ```python
->>> service = Directions()
+>>> service = Directions(access_token="pk.YOUR_ACCESS_TOKEN")
 
 ```
 


### PR DESCRIPTION
Add the access token when creating the direction object to avoid 401 responses.