### PR TITLE
Remove duplicate operation on tileset

### DIFF
--- a/mapbox/services/uploads.py
+++ b/mapbox/services/uploads.py
@@ -273,6 +273,5 @@ class Uploader(Service):
         -------
         requests.Response
         """
-        tileset = self._validate_tileset(tileset)
         url = self.stage(fileobj, callback=callback)
         return self.create(url, tileset, name=name, patch=patch)


### PR DESCRIPTION
Remove duplicate tileset validation.

```python
self._validate_tileset(tileset)
```
is called right after in `create` function