### PR TITLE
add bypass flag for uploads service

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,11 @@
 Changes
 =======
 
-0.17.2 (2019-11-30)
+0.18.0 (2019-03-05)
+-------------------
+- Added support for bypass_mbtiles_validation flag in the Uploads API (#271)
+
+0.17.2 (2018-11-30)
 -------------------
 
 Bug fixes:
@@ -41,7 +45,7 @@ New features:
 - Added support for Directions v5 (#203).
 - The Mapbox Distance API is no more and the distance module has been deleted
   (#232). Users must use the DirectionsMatrix introduced in 0.15.
-- Project documentation is now on Read the Docs: 
+- Project documentation is now on Read the Docs:
   https://mapbox-mapbox.readthedocs-hosted.com/en/latest/.
 
 0.15.1 (2018-01-16)

--- a/mapbox/__init__.py
+++ b/mapbox/__init__.py
@@ -1,5 +1,5 @@
 # mapbox
-__version__ = "0.17.2"
+__version__ = "0.18.0"
 
 from .services.datasets import Datasets
 from .services.directions import Directions

--- a/mapbox/services/uploads.py
+++ b/mapbox/services/uploads.py
@@ -116,7 +116,7 @@ class Uploader(Service):
 
         return creds['url']
 
-    def create(self, stage_url, tileset, name=None, patch=False):
+    def create(self, stage_url, tileset, name=None, patch=False, bypass=False):
         """Create a tileset
 
         Note: this step is refered to as "upload" in the API docs;
@@ -144,6 +144,9 @@ class Uploader(Service):
         patch: bool
             Optional patch mode which requires a flag on the owner's
             account.
+        bypass: bool
+            Optional bypass validation mode for MBTiles which requires
+            a flag on the owner's account.
 
         Returns
         -------
@@ -157,6 +160,9 @@ class Uploader(Service):
 
         if patch:
             msg['patch'] = patch
+
+        if bypass:
+            msg['bypass_mbtiles_validation'] = bypass
 
         msg['name'] = name if name else _name
 
@@ -246,7 +252,7 @@ class Uploader(Service):
         self.handle_http_error(resp)
         return resp
 
-    def upload(self, fileobj, tileset, name=None, patch=False, callback=None):
+    def upload(self, fileobj, tileset, name=None, patch=False, callback=None, bypass=False):
         """Upload data and create a Mapbox tileset
 
         Effectively replicates the Studio upload feature. Returns a
@@ -265,6 +271,9 @@ class Uploader(Service):
         patch: bool
             Optional patch mode which requires a flag on the owner's
             account.
+        bypass: bool
+            Optional bypass validation mode for MBTiles which requires
+            a flag on the owner's account.
         callback: func
             A function that takes a number of bytes processed as its
             sole argument. May be used with a progress bar.
@@ -275,4 +284,4 @@ class Uploader(Service):
         """
         tileset = self._validate_tileset(tileset)
         url = self.stage(fileobj, callback=callback)
-        return self.create(url, tileset, name=name, patch=patch)
+        return self.create(url, tileset, name=name, patch=patch, bypass=bypass)


### PR DESCRIPTION
Adds a flag alongside patch for bypassing mbtiles uploads (which requires the feature to be enabled on a user's account).

cc @ivovandongen @ian29 @sgillies 