### PR TITLE
fix(mapbox/utils): make collections import future-proof

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ cd mapbox-sdk-py
 
 Install in "editable" mode with testing dependencies
 ```
-pip install -e .[test]
+pip install -e ".[test]"
 ```
 
 And finally create a separate branch to begin work
@@ -36,10 +36,10 @@ git checkout -b my-new-feature
 
 ## Submitting Pull Requests
 
-Pull requests are welcomed! We'd like to review the design and implementation as early as 
-possible so please submit the pull request even if it's not 100%. 
+Pull requests are welcomed! We'd like to review the design and implementation as early as
+possible so please submit the pull request even if it's not 100%.
 Let us know the purpose of the change and list the remaining items which need to be
-addressed before merging. Finally, PR's should include unit tests and documentation 
+addressed before merging. Finally, PR's should include unit tests and documentation
 where appropriate.
 
 ## Code of conduct

--- a/mapbox/utils.py
+++ b/mapbox/utils.py
@@ -1,4 +1,8 @@
-from collections import Mapping, Sequence
+import sys
+try:
+    from collections.abc import Mapping, Sequence
+except ImportError:
+    from collections import Mapping, Sequence
 
 
 def normalize_geojson_featurecollection(obj):

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = 
-    py27,py36
+envlist =
+    py27,py36,py37,py38
 
 [testenv]
 deps =
     pytest-cov
     responses
-commands = 
+commands =
     python -m pytest --cov mapbox --cov-report term-missing


### PR DESCRIPTION
```
mapbox/utils.py:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
  from collections import Mapping, Sequence
```

---

Python 3.9 will make the `collections` import to stop working. This changes the default import
for Python 3+ to use `collections.abc` instead.

### Other changes:

- Update `CONTRIBUTING` guidelines to use quotes so that it plays nicely with other shells (zsh,
  for example)
- Include Python 3.7 and 3.8 to the `tox.ini` configuration so that the existing test suite is
  checked for potential compatibility issues caused by the change of imported module.